### PR TITLE
resolve n+1 query problem

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -6,7 +6,12 @@ class Api::EventsController < ApplicationController
   end
 
   def get_events
-    User.find(params[:user_id]).events.offset(start_id).limit(count)
+    # Do not remove the "includes". This allows us to eager load the
+    # users association for each event.  Thereby avoiding
+    # the n+1 query problem because of the JBuilder view where
+    # each event is iterated over and the associated users (members)
+    # are included in the response payload.
+    User.find(params[:user_id]).events.includes(:users).offset(start_id).limit(count)
   end
 
   def default_count


### PR DESCRIPTION
@cchanningallen 

This resolves the n+1 query problem you noticed.  Turns out it was an issue in how JBuilder was building the payload.  The only way to get JBuilder to build the payload we designed is by iterating through each event and finding all users.  That looping over events is what caused the n+1 problem.  The solution is to eager load the users associated to the events in the controller when we call on the events.  That way all the events and users are in memory in 2 queries instead of events + 1 queries.

Old query output:
```
Rendering api/events/index.json.jbuilder
  User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Event Load (0.6ms)  SELECT  "events".* FROM "events" INNER JOIN "event_members" ON "events"."id" = "event_members"."event_id" WHERE "event_members"."user_id" = ? LIMIT ? OFFSET ?  [["user_id", 1], ["LIMIT", 20], ["OFFSET", 0]]
  User Load (0.6ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 1]]
  User Load (0.5ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 3]]
  User Load (0.2ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 4]]
  User Load (0.5ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 6]]
  User Load (0.3ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 7]]
  User Load (0.3ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 10]]
  User Load (0.6ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 12]]
  User Load (0.2ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 14]]
  User Load (0.2ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 15]]
  User Load (0.2ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 16]]
  User Load (0.4ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 17]]
  User Load (0.2ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 18]]
  User Load (0.2ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 19]]
  User Load (0.2ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 24]]
  User Load (0.4ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 28]]
  User Load (0.4ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 29]]
  User Load (0.2ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 31]]
  User Load (0.2ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 32]]
  User Load (0.4ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 35]]
  User Load (0.2ms)  SELECT "users".* FROM "users" INNER JOIN "event_members" ON "users"."id" = "event_members"."user_id" WHERE "event_members"."event_id" = ?  [["event_id", 41]]
  Rendered api/events/index.json.jbuilder (158.3ms)
```

New query output:
```
Rendering api/events/index.json.jbuilder
  User Load (0.1ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = ? LIMIT ?  [["id", 1], ["LIMIT", 1]]
  Event Load (0.2ms)  SELECT  "events".* FROM "events" INNER JOIN "event_members" ON "events"."id" = "event_members"."event_id" WHERE "event_members"."user_id" = ? LIMIT ? OFFSET ?  [["user_id", 1], ["LIMIT", 20], ["OFFSET", 0]]
  EventMember Load (0.9ms)  SELECT "event_members".* FROM "event_members" WHERE "event_members"."event_id" IN (1, 3, 4, 6, 7, 10, 12, 14, 15, 16, 17, 18, 19, 24, 28, 29, 31, 32, 35, 41)
  User Load (0.4ms)  SELECT "users".* FROM "users" WHERE "users"."id" IN (3, 19, 22, 21, 12, 18, 5, 11, 4, 1, 14, 17, 13, 8, 15, 6, 9, 7, 2, 10, 23, 16, 20)
  Rendered api/events/index.json.jbuilder (60.0ms)
```